### PR TITLE
Resolve dependency sources in all repositories.

### DIFF
--- a/plugins/gradle/java/src/util/GradleAttachSourcesProvider.java
+++ b/plugins/gradle/java/src/util/GradleAttachSourcesProvider.java
@@ -101,7 +101,9 @@ public class GradleAttachSourcesProvider implements AttachSourcesProvider {
                             "        project.dependencies.add('downloadSources', '" + artifactCoordinates + ":sources" + "')\n" +
                             "        project.tasks.create(name: '" + taskName + "', overwrite: true) {\n" +
                             "        doLast {\n" +
-                            "          project.configurations.downloadSources.resolve()\n" +
+                            "          if (!project.configurations.downloadSources.resolvedConfiguration.lenientConfiguration.getFiles().any()) {\n" +
+                            "            project.configurations.downloadSources.resolvedConfiguration.rethrowFailure()\n" +
+                            "          }\n" +
                             "        }\n" +
                             "      }\n" +
                             "    }\n" +
@@ -172,3 +174,4 @@ public class GradleAttachSourcesProvider implements AttachSourcesProvider {
     return result;
   }
 }
+


### PR DESCRIPTION
As reported here: https://discuss.gradle.org/t/idea-plugin-isnt-downloading-sources-when-mavenlocal-is-used/2160 library sources are not downloaded for certain gradle configurations. 

Download source fails when the first maven repository configured doesn't already contain the artifact requested, a common case of this issue is use of mavenLocal which likely does not already have sources present.